### PR TITLE
Add nav bar for desktop

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -32,7 +32,7 @@ const VertNav = styled.div`
 `;
 
 const MenuItem = styled.div`
-    padding: 0.5rem 1rem;
+    padding: 1rem 2rem;
     a {
         text-decoration: none;
         color: ${theme.colors.white};

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -18,17 +18,36 @@ const Container = styled.div`
     }
 `;
 
+const VertNav = styled.div`
+    font-family: 'Barlow', sans-serif;
+    font-weight: bold;
+    text-align: right;
+    position: fixed;
+    right: 1vw;
+    top:3vh;
+    font-weight:700;
+    z-index:100;
+    @media only screen and (max-width: 768px){
+    }
+`;
+
 const MenuItem = styled.div`
     padding: 0.5rem 1rem;
     a {
         text-decoration: none;
-        color: ${theme.colors.black};
+        color: ${theme.colors.white};
+        
     }
+
+    a:hover {
+        color: #ACBAED;
+    }
+    
 `;
 
 const NavBar = ({ }) => {
     return (
-        <Container>
+        <VertNav>
             <MenuItem>
                 <a href="https://www.columbiaspectator.com/" style={{
                 }}><img style={{
@@ -41,7 +60,7 @@ const NavBar = ({ }) => {
                     <Link to={section.url}>{section.title}</Link>
                 </MenuItem>
             ))}
-        </Container>
+        </VertNav>
     )
 };
 

--- a/src/data/sections.js
+++ b/src/data/sections.js
@@ -1,19 +1,19 @@
 export const sections = [
     {
-        title: "Home",
+        title: "HOME",
         url: "/",
         exact: true,
     },
     {
-        title: "News",
+        title: "NEWS",
         url: "/news",
     },
     {
-        title: "Opinion",
+        title: "OPINION",
         url: "/opinion",
     },
     {
-        title: "Sports",
+        title: "SPORTS",
         url: "/sports",
     },
     {
@@ -21,7 +21,7 @@ export const sections = [
         url: "/a&e",
     },
     {
-        title: "The Eye",
+        title: "THE EYE",
         url: "/eye",
     },
 ];


### PR DESCRIPTION
Nav bar is typically white, but changes to light blue when hovering over section.

This fixes #5.

nav bar:
<img width="128" alt="image" src="https://user-images.githubusercontent.com/95725924/192911365-a47e6276-21af-41e3-9c2c-b0e45fc92cc0.png">

nav bar when hovering over section:
<img width="184" alt="image" src="https://user-images.githubusercontent.com/95725924/192911403-771c08a6-23cd-49f2-a157-6be6ef26d7e9.png">
<img width="130" alt="image" src="https://user-images.githubusercontent.com/95725924/192911452-be1fafbd-b47a-46f9-8144-9ee19f558b9d.png">

