### PR TITLE
Add mobile version of rainbow container

### DIFF
--- a/src/components/Rainbow.js
+++ b/src/components/Rainbow.js
@@ -16,13 +16,32 @@ const VerticalTitle = styled.div`
     float: right;
     display: flex;
     align-self: center;
+
+    @media only screen and (max-width: 768px){
+        display: none;
+    }
 `;
+
+const HorizontalTitle = styled.div`
+    display: none;
+
+    @media only screen and (max-width: 768px) {
+        font-size: 2.5rem;
+        font-weight: bold;
+        color: white;
+        margin: 2rem;
+        display: flex;
+        align-self: left;
+    }
+`
 
 const Container = styled.div`
     background-color: lavender;
     display: flex;
+
     @media only screen and (max-width: 768px){
-    }   
+        overflow: visible;
+    }
 `;
 
 const Flag = styled.div`
@@ -32,6 +51,11 @@ const Flag = styled.div`
     display: flex;
     height: 100vh;
     width: 100%;
+    
+    @media only screen and (max-width: 768px){
+        flex-direction: column;
+        height: fit-content;
+    }
 `;
 
 const Modal = styled.div`
@@ -57,12 +81,17 @@ const Color = styled.div`
     overflow: scroll;
     transition-duration:0.5s;
     padding-top: 3rem;
+
+    @media only screen and (max-width: 768px){
+        flex-direction: column;
+        padding-top: 0rem;
+    }
 `;
 
 const Stripe = ({ open, color, saturated, title, articles }) => {
     return (
         <Color open={open} color={color} saturated={saturated}>
-
+            <HorizontalTitle>{title}</HorizontalTitle>
             <Column open={open}>
                 {articles.map(article => (
                     <Article


### PR DESCRIPTION
Instead of the horizontally stacked color stripes on the desktop version, the flag is stacked horizontally as shown below. The title is also horizontal goes above the articles instead of next to them.

notes: the article cards are not currently centered

this fixes #12 

closed:
<img width="311" alt="image" src="https://user-images.githubusercontent.com/95725924/193472620-e18d05ce-8815-4454-bd10-2afd1d1d0b56.png">

open news section:
<img width="303" alt="image" src="https://user-images.githubusercontent.com/95725924/193472643-d6fd6bcc-e3b6-478c-b179-1762ef374d10.png">
<img width="306" alt="image" src="https://user-images.githubusercontent.com/95725924/193472740-81662e09-10d5-475f-a3fc-37e02167daf8.png">
<img width="305" alt="image" src="https://user-images.githubusercontent.com/95725924/193472652-f9ad11f7-0f2e-4281-bd47-a293656472e6.png">

