### PR TITLE
Credits

### DIFF
--- a/src/components/Credits.js
+++ b/src/components/Credits.js
@@ -6,6 +6,9 @@ import theme from '../theme';
 const Title = styled.div`
     align-items: center;
     justify-content: center;
+    margin-left: auto;
+    margin-right: auto;
+    overflow-wrap: break-word;
     font-size: 2.5rem;
     color: rgba(0, 117, 255, 0.8);
 `;
@@ -17,27 +20,26 @@ const Container = styled.div`
     @media only screen and (max-width: 768px){
     }
 `;
-const LetterWrap = styled.div`
-    padding-top:5vh;
-    border:solid 1px white;
-    margin-top:5vh;
-    margin-bottom: 2rem;
-    @media (max-width: 768px) {
-        margin-left:4%;
-        margin-right:4%;
-    }
-`;
+
 
 const Body = styled.div`
-    display:flex;
+    display: flex;
+    -webkit-box-pack: center;
     justify-content: center;
 `;
 
+const Spacing = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    text-align: left;
+`;
+
+
 const SubDiv = styled.div`
-    width: 25vw;
-    padding-left: 1rem;
+    width: 33%;
+    padding: 0.5rem;
     font-family: Josefin Sans;
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     @media ${device.tablet} {
         width: fit-content;
     }
@@ -45,11 +47,19 @@ const SubDiv = styled.div`
 `;
 const Section = styled.div`
     padding-bottom:1em;
-    // flex-grow: 1;
+`;
+
+const H = styled.div`
+    display: block;
+    font-size: 1.17em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
 `;
 
 const Row = styled.div`
-    flex-direction: row;
     display: flex;
     text-align: left;
     
@@ -69,11 +79,13 @@ const dep = styled.div`
 `;
 
 const Border = styled.div`
-    border: 1px solid ${({ color }) => color || "CornflowerBlue"};
-    padding: 4rem;
-    padding-top: 5rem;
+    border-image: linear-gradient(45deg, #f79533, #f37055, #ef4e7b, #a166ab, #5073b8, #1098ad, #07b39b, #6fba82) 1;
+    border-width: 1rem;
+    border-style: dashed;
+    padding: 5rem 8rem 5rem 8rem;
     @media only screen and (max-width: 768px){
-        padding: 20px;
+        padding: 2rem;
+        border-width: 0.5rem;
     }
 `;
 
@@ -84,54 +96,62 @@ const Credits = ({ }) => {
             <Title>
                 THE COLUMBIA DAILY SPECTATOR STAFF WHO MADE THIS ISSUE POSSIBLE
             </Title>
+            <Spacing>
             <Body>
                 <Row>
-                
-                
                     <SubDiv>
                         <Section>
-                            <h3>Corporate Board</h3>
-                
+                            <H>Corporate Board</H>
+                            <p>Clara Ence Morse, Editor-in-Chief</p>
+                            <p>Dia Gill, Managing Editor</p>
+                            <p>Vilanna Wang, Publisher</p>
                         </Section>
                         <Section>
-                            <h3>University News</h3>      
+                            <H>University News</H> 
+                            <p>Irie Sentner, University News Editor</p> 
+                            <p>Zachary Schermele, Deputy News Editor</p>    
                         </Section>
                         <Section>
-                            <h3>Arts and Entertainment</h3>
+                            <H>Arts and Entertainment</H>
                         </Section>
                         <Section>
-                            <h3>Illustrations</h3> 
+                            <H>Illustrations</H> 
 
                         </Section>
                     </SubDiv>
                     <SubDiv>
                         <Section>
-                            <h3>Design and Development</h3>
-            
+                            <H>Design and Development</H>
+                            <p>Laura Castro Venegas, Head of Engineering</p>
+                            <p>Philippe Wu, Head of Product</p>
+                            <p>Marian Abuhazi, Engineering Manager</p>
+                            <p>Maya Srikanth, Engineering Manager</p>
+
                         </Section>
                         <Section>
-                            <h3>Opinion</h3>
+                            <H>Opinion</H>
                            
                         </Section>
                         <Section>
-                            <h3>Photo</h3>
+                            <H>Photo</H>
                         </Section>
                     </SubDiv>
                     <SubDiv>
                         <Section>
-                            <h3>Lead Illustration By</h3>
+                            <H>Lead Illustration By</H>
                             <p>Ji Yoon Sim, Deputy Illustrations Editor</p>
                         </Section>
                         <Section>
-                            <h3>Copy</h3>
+                            <H>Copy</H>
+                            <p>Olivia Vella, Head Copy Editor</p>
+                            <p>Kaylene Su Yee Chong, Deputy Copy Editor</p>
+                        </Section>
+                        <Section>
+                            <H>Spectrum</H>
                           
                         </Section>
                         <Section>
-                            <h3>Spectrum</h3>
-                          
-                        </Section>
-                        <Section>
-                            <h3>Sports</h3>
+                            <H>Sports</H>
                           
                         </Section>
                     </SubDiv>
@@ -141,6 +161,7 @@ const Credits = ({ }) => {
                 
 
             </Body>
+            </Spacing>
             </Border>
         </Container>
 

--- a/src/components/Credits.js
+++ b/src/components/Credits.js
@@ -11,6 +11,9 @@ const Title = styled.div`
     overflow-wrap: break-word;
     font-size: 2.5rem;
     color: rgba(0, 117, 255, 0.8);
+    @media only screen and (max-width: 768px){
+        font-size: 1.75rem;
+    }
 `;
 
 const Container = styled.div`
@@ -40,8 +43,13 @@ const SubDiv = styled.div`
     padding: 0.5rem;
     font-family: Josefin Sans;
     font-size: 1.2rem;
-    @media ${device.tablet} {
+    @media only screen and (max-width: 768px){
         width: fit-content;
+        font-size: 0.75rem;
+    }
+    @media (min-width: 768px){
+        width: fit-content;
+        font-size: 0.75rem;
     }
     color: rgba(0, 117, 255, 0.8);
 `;
@@ -134,6 +142,7 @@ const Credits = ({ }) => {
                         </Section>
                         <Section>
                             <H>Photo</H>
+                            <p>Millie Felder, Photo Editor</p>
                         </Section>
                     </SubDiv>
                     <SubDiv>
@@ -152,14 +161,9 @@ const Credits = ({ }) => {
                         </Section>
                         <Section>
                             <H>Sports</H>
-                          
                         </Section>
                     </SubDiv>
-                    
                 </Row>
-                
-                
-
             </Body>
             </Spacing>
             </Border>

--- a/src/components/Credits.js
+++ b/src/components/Credits.js
@@ -4,24 +4,146 @@ import { device } from '../device';
 import theme from '../theme';
 
 const Title = styled.div`
-    font-size: 2rem;
-    font-weight: bold;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.5rem;
+    color: rgba(0, 117, 255, 0.8);
 `;
 
 const Container = styled.div`
-    background-color: lightpink;
+    background-color: white;
     height: 15rem;
+    padding: 50px;
     @media only screen and (max-width: 768px){
+    }
+`;
+const LetterWrap = styled.div`
+    padding-top:5vh;
+    border:solid 1px white;
+    margin-top:5vh;
+    margin-bottom: 2rem;
+    @media (max-width: 768px) {
+        margin-left:4%;
+        margin-right:4%;
+    }
+`;
+
+const Body = styled.div`
+    display:flex;
+    justify-content: center;
+`;
+
+const SubDiv = styled.div`
+    width: 25vw;
+    padding-left: 1rem;
+    font-family: Josefin Sans;
+    font-size: 1.5rem;
+    @media ${device.tablet} {
+        width: fit-content;
+    }
+    color: rgba(0, 117, 255, 0.8);
+`;
+const Section = styled.div`
+    padding-bottom:1em;
+    // flex-grow: 1;
+`;
+
+const Row = styled.div`
+    flex-direction: row;
+    display: flex;
+    text-align: left;
+    
+    
+    /*@media (max-width: 1000px) {
+        font-size:0.75em;
+    }
+    @media (max-width: 768px) {
+        margin-left:1.25em;
+        font-size:1em !important;
+        text-align: center;
+    }*/
+`;
+
+const dep = styled.div`
+    font-weight: 400;
+`;
+
+const Border = styled.div`
+    border: 1px solid ${({ color }) => color || "CornflowerBlue"};
+    padding: 4rem;
+    padding-top: 5rem;
+    @media only screen and (max-width: 768px){
+        padding: 20px;
     }
 `;
 
 const Credits = ({ }) => {
     return (
         <Container>
+            <Border>
             <Title>
-                Credits
+                THE COLUMBIA DAILY SPECTATOR STAFF WHO MADE THIS ISSUE POSSIBLE
             </Title>
+            <Body>
+                <Row>
+                
+                
+                    <SubDiv>
+                        <Section>
+                            <h3>Corporate Board</h3>
+                
+                        </Section>
+                        <Section>
+                            <h3>University News</h3>      
+                        </Section>
+                        <Section>
+                            <h3>Arts and Entertainment</h3>
+                        </Section>
+                        <Section>
+                            <h3>Illustrations</h3> 
+
+                        </Section>
+                    </SubDiv>
+                    <SubDiv>
+                        <Section>
+                            <h3>Design and Development</h3>
+            
+                        </Section>
+                        <Section>
+                            <h3>Opinion</h3>
+                           
+                        </Section>
+                        <Section>
+                            <h3>Photo</h3>
+                        </Section>
+                    </SubDiv>
+                    <SubDiv>
+                        <Section>
+                            <h3>Lead Illustration By</h3>
+                            <p>Ji Yoon Sim, Deputy Illustrations Editor</p>
+                        </Section>
+                        <Section>
+                            <h3>Copy</h3>
+                          
+                        </Section>
+                        <Section>
+                            <h3>Spectrum</h3>
+                          
+                        </Section>
+                        <Section>
+                            <h3>Sports</h3>
+                          
+                        </Section>
+                    </SubDiv>
+                    
+                </Row>
+                
+                
+
+            </Body>
+            </Border>
         </Container>
+
     )
 };
 

--- a/src/components/Credits.js
+++ b/src/components/Credits.js
@@ -6,13 +6,10 @@ import theme from '../theme';
 const Title = styled.div`
     align-items: center;
     justify-content: center;
-    margin-left: auto;
-    margin-right: auto;
-    overflow-wrap: break-word;
     font-size: 2.5rem;
     color: rgba(0, 117, 255, 0.8);
     @media only screen and (max-width: 768px){
-        font-size: 1.75rem;
+        font-size: 1.5rem;
     }
 `;
 
@@ -26,9 +23,9 @@ const Container = styled.div`
 
 
 const Body = styled.div`
-    display: flex;
+    /*display: flex;
     -webkit-box-pack: center;
-    justify-content: center;
+    justify-content: center;*/
 `;
 
 const Spacing = styled.div`
@@ -39,16 +36,11 @@ const Spacing = styled.div`
 
 
 const SubDiv = styled.div`
-    width: 33%;
-    padding: 0.5rem;
+    width: 33.33%;
+    padding: 1%;
     font-family: Josefin Sans;
-    font-size: 1.2rem;
+    font-size: 1.5rem;
     @media only screen and (max-width: 768px){
-        width: fit-content;
-        font-size: 0.75rem;
-    }
-    @media (min-width: 768px){
-        width: fit-content;
         font-size: 0.75rem;
     }
     color: rgba(0, 117, 255, 0.8);
@@ -70,16 +62,6 @@ const H = styled.div`
 const Row = styled.div`
     display: flex;
     text-align: left;
-    
-    
-    /*@media (max-width: 1000px) {
-        font-size:0.75em;
-    }
-    @media (max-width: 768px) {
-        margin-left:1.25em;
-        font-size:1em !important;
-        text-align: center;
-    }*/
 `;
 
 const dep = styled.div`
@@ -92,7 +74,7 @@ const Border = styled.div`
     border-style: dashed;
     padding: 5rem 8rem 5rem 8rem;
     @media only screen and (max-width: 768px){
-        padding: 2rem;
+        padding: 1rem;
         border-width: 0.5rem;
     }
 `;
@@ -121,10 +103,11 @@ const Credits = ({ }) => {
                         </Section>
                         <Section>
                             <H>Arts and Entertainment</H>
+                            <p>Bella Druckman, Arts and Entertainment Editor</p>
                         </Section>
                         <Section>
                             <H>Illustrations</H> 
-
+                            <p>Yingjie Wang, Illustrations Editor</p>
                         </Section>
                     </SubDiv>
                     <SubDiv>
@@ -138,7 +121,7 @@ const Credits = ({ }) => {
                         </Section>
                         <Section>
                             <H>Opinion</H>
-                           
+                            <p>Senem Yurdakul, Editorial Page Editor</p>
                         </Section>
                         <Section>
                             <H>Photo</H>
@@ -157,10 +140,13 @@ const Credits = ({ }) => {
                         </Section>
                         <Section>
                             <H>Spectrum</H>
-                          
+                            <p>Ariana Novo, Spectrum Editor</p>
+                            <p>Emma Cho, Deputy Spectrum Editor</p>
                         </Section>
                         <Section>
                             <H>Sports</H>
+                            <p>Miles Schachner, Sports Editor</p>
+                            <p>Rebecca Wachen, Deputy Sports Editor</p>
                         </Section>
                     </SubDiv>
                 </Row>


### PR DESCRIPTION
I formatted the credits page and added the same rainbow border from Letter to the Editor. 

An issue I ran into was formatting for the mobile app, it needs to be fixed so when pulling the screen smaller, format rearranges to only one column. 

<img width="1377" alt="Credits_Desktop" src="https://user-images.githubusercontent.com/42629013/194156204-9a221607-e382-4429-8c58-a7d28e7b7309.png">
<img width="586" alt="Credits_Mobile" src="https://user-images.githubusercontent.com/42629013/194156208-01130bb0-5c90-441d-abe5-46dfb5262318.png">
<img width="311" alt="Credits_Mobile_Reformat" src="https://user-images.githubusercontent.com/42629013/194156219-8c882f98-a12d-47f4-bdd4-87432f8bac08.png">
